### PR TITLE
Use RAWGIT for potentially-correct meta-type, md fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ http://www.ipdeny.com/ipblocks/data/aggregated/cn-aggregated.zone
 
 ## 使用姿势
 
-```bash
-// 安装 io.js 与 npm
-// 根据需求修改 index.js 文件中的 CIDR_PATH / PAC_PATH / PROXY 三个常量
+```sh
+# 安装 io.js 与 npm
+# 根据需求修改 index.js 文件中的 CIDR_PATH / PAC_PATH / PROXY 三个常量
 
-$ git clone https://github.com/wspl/CIDR2PAC.git
-$ cd ./CIDR2PAC
-$ npm install
-$ iojs ./
+git clone https://github.com/wspl/CIDR2PAC.git
+cd ./CIDR2PAC
+npm install
+iojs ./
 
-// 然后就可以在 PAC_PATH 对应目录找到你的 PAC 文件。
+# 然后就可以在 PAC_PATH 对应目录找到你的 PAC 文件。
 ```
 
 
@@ -29,5 +29,5 @@ $ iojs ./
 该 PAC 文件将使国内 IP 网站跳过代理，非国内 IP 网站走 `127.0.0.1:1080` 的代理。
 
 
-Github Raw： https://raw.githubusercontent.com/wspl/CIDR2PAC/master/whitelist.pac
-（可以直接贴到浏览器代理设置的 pac 地址栏中，当然首先得能访问 Github _(:з」∠)_）
+Github Raw： https://rawgit.com/wspl/CIDR2PAC/master/whitelist.pac
+（可以直接贴到浏览器代理设置的 pac 地址栏中，当然首先得能访问 Github \_(:з」∠)\_）


### PR DESCRIPTION
用 Rawgit 的话 GH 的服务器不会每次都返回 text/plain，而是会考虑一下后缀之类的，当然链接短是重点。

颜文字被解析成了 Markdown，我反转义一下。
另外就是命令行的姿势……
