### PR TITLE
dnsResolve can be null

### DIFF
--- a/whitelist_template.pac
+++ b/whitelist_template.pac
@@ -18,7 +18,11 @@ function ipToLong(ip) {
 }
 
 function isInside(host) {
-  var testIpLong = ipToLong(dnsResolve(host));
+  var ip = dnsResolve(host);
+  if (!ip) {
+    return false;
+  }
+  var testIpLong = ipToLong(ip);
 
   var startRange = 0;
   var endRange = ipRepo.length;


### PR DESCRIPTION
一些被墙的域名使用国内dns无法解析，此时dnsResolve会返回null
![image](https://cloud.githubusercontent.com/assets/1574994/16797533/98e3d94a-491a-11e6-8629-3fcf560df4dc.png)
