### PR TITLE
添加文件：Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ RUN curl -fsSk -o cn-aggregated.zone.txt http://www.ipdeny.com/ipblocks/data/agg
   && mv whitelist.pac index.html
 
 
-EXPOSE ["8080"]
+EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/http-server", "/var/tmp/"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,24 +3,17 @@ MAINTAINER Jiahao Dai <jiahao.dai@hypers.com>
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update \
-  && apt-get install --force-yes -y \
-    git \
-  \
-  && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/* \
-  && rm -rf /tmp/* \
-  && rm -rf /usr/{{lib,share}/locale,share/{man,doc,info,gnome/help,cracklib,il8n},{lib,lib64}/gconv,bin/localedef,sbin/build-locale-archive}
+ADD index.js /var/tmp/index.js
+ADD package.json /var/tmp/package.json
+ADD whitelist_template.pac /var/tmp/whitelist_template.pac
 
 WORKDIR /var/tmp/
-RUN git clone --depth=1 https://github.com/wspl/CIDR2PAC.git \
-  && cd /var/tmp/CIDR2PAC \
-  && curl -fsSk -o cn-aggregated.zone.txt http://www.ipdeny.com/ipblocks/data/aggregated/cn-aggregated.zone \
+RUN curl -fsSk -o cn-aggregated.zone.txt http://www.ipdeny.com/ipblocks/data/aggregated/cn-aggregated.zone \
   && npm install \
   && npm install http-server -g \
   && node ./ \
   && mv whitelist.pac index.html
 
 
-VOLUME 8080
-ENTRYPOINT ["http-server", "./"]
+PORT 8080
+ENTRYPOINT ["/usr/local/bin/http-server", "/var/tmp/"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:6
+MAINTAINER Jiahao Dai <jiahao.dai@hypers.com>
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update \
+  && apt-get install --force-yes -y \
+    git \
+  \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /tmp/* \
+  && rm -rf /usr/{{lib,share}/locale,share/{man,doc,info,gnome/help,cracklib,il8n},{lib,lib64}/gconv,bin/localedef,sbin/build-locale-archive}
+
+WORKDIR /var/tmp/
+RUN git clone --depth=1 https://github.com/wspl/CIDR2PAC.git \
+  && cd /var/tmp/CIDR2PAC \
+  && curl -fsSk -o cn-aggregated.zone.txt http://www.ipdeny.com/ipblocks/data/aggregated/cn-aggregated.zone \
+  && npm install \
+  && npm install http-server -g \
+  && node ./ \
+  && mv whitelist.pac index.html
+
+
+VOLUME 8080
+ENTRYPOINT ["http-server", "./"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM node:6
 MAINTAINER Jiahao Dai <jiahao.dai@hypers.com>
 
-ENV DEBIAN_FRONTEND noninteractive
-
 ADD index.js /var/tmp/index.js
 ADD package.json /var/tmp/package.json
 ADD whitelist_template.pac /var/tmp/whitelist_template.pac
@@ -15,5 +13,5 @@ RUN curl -fsSk -o cn-aggregated.zone.txt http://www.ipdeny.com/ipblocks/data/agg
   && mv whitelist.pac index.html
 
 
-PORT 8080
+EXPOSE ["8080"]
 ENTRYPOINT ["/usr/local/bin/http-server", "/var/tmp/"]


### PR DESCRIPTION
经过diff 项目中的CIDR已经有近600行的变化（应该不影响实际使用...)     
做了一个Dockerfile，从而每次手动build镜像就能获得最新CIDR，得到更新过的PAC。最终以网址形式呈现。        

我已经在国内某CaaS服务商上测试过[构建过程](http://hub.daocloud.io/repos/688d0ec1-8817-441b-bc77-bda0b1b67ef6)。    
[在线pac网址](http://whitelist-cn-pac.daoapp.io/)内容也经过本机测试。     
  
请考虑Merge，我会稍后更新Readme。